### PR TITLE
add repository metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "contributors": [
     "Woong Jun <woong.jun@gmail.com> (http://code.woong.org/)"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/timoxley/wcwidth.git"
+  },
   "main": "index.js",
   "dependencies": {
     "defaults": "^1.0.0"


### PR DESCRIPTION
Unfortunately your wcwidth library doesn't contain a `repository` metadata field.
And as a result our dependency manager won't process it. Which has halted our project. :-(
Can you please republish your 1.0.0 component with this pull request? I've filled the repository metadata with a link to your repo.

Please no new version since it's a transitive dependency.
Thanks so much!
