### PR TITLE
Bump minimum `node` version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+branches:
+  only:
+    - "master"
+
+git:
+  depth: 3
+
+language: node_js
+
+node_js:
+  - "4"
+  - "10"
+
+script:
+  - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ language: node_js
 
 node_js:
   - "4"
+  - "6"
+  - "8"
   - "10"
 
 script:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 "use strict"
 
-var defaults = require('defaults')
 var combining = require('./combining')
 
 var DEFAULTS = {
@@ -13,7 +12,7 @@ module.exports = function wcwidth(str) {
 }
 
 module.exports.config = function(opts) {
-  opts = defaults(opts || {}, DEFAULTS)
+  opts = Object.assign({}, DEFAULTS, opts)
   return function wcwidth(str) {
     return wcswidth(str, opts)
   }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "contributors": [
     "Woong Jun <woong.jun@gmail.com> (http://code.woong.org/)"
   ],
-  "main": "index.js",
-  "dependencies": {
-    "defaults": "^1.0.3"
+  "engines": {
+    "node": ">=4"
   },
+  "main": "index.js",
   "devDependencies": {
     "tape": "^4.5.1"
   },


### PR DESCRIPTION
To `node>=4`.  Closes #4.